### PR TITLE
expose s3 lifecycle options

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Available targets:
 | expiration\_days | Number of days after which to expunge s3 logs | `number` | `90` | no |
 | glacier\_transition\_days | Number of days after which to move s3 logs to the glacier storage tier | `number` | `60` | no |
 | health\_check\_enabled | A boolean flag to enable/disable the NLB health checks | `bool` | `true` | no |
-| health\_check\_interval | The duration in seconds in between health checks | `number` | `15` | no |
+| health\_check\_interval | The duration in seconds in between health checks | `number` | `10` | no |
 | health\_check\_path | The destination for the health check request | `string` | `"/"` | no |
 | health\_check\_port | The port to send the health check request to (defaults to `traffic-port`) | `number` | `null` | no |
 | health\_check\_protocol | The protocol to use for the health check request | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -167,60 +167,83 @@ Available targets:
   lint                                Lint terraform code
 
 ```
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.0 |
+| aws | ~> 2.0 |
+| local | ~> 1.3 |
+| null | ~> 2.0 |
+| template | ~> 2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2.0 |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| access_logs_enabled | A boolean flag to enable/disable access_logs | bool | `true` | no |
-| access_logs_prefix | The S3 log bucket prefix | string | `` | no |
-| access_logs_region | The region for the access_logs S3 bucket | string | `us-east-1` | no |
-| attributes | Additional attributes (_e.g._ "1") | list(string) | `<list>` | no |
-| certificate_arn | The ARN of the default SSL certificate for HTTPS listener | string | `` | no |
-| cross_zone_load_balancing_enabled | A boolean flag to enable/disable cross zone load balancing | bool | `true` | no |
-| deletion_protection_enabled | A boolean flag to enable/disable deletion protection for NLB | bool | `false` | no |
-| delimiter | Delimiter between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
-| deregistration_delay | The amount of time to wait in seconds before changing the state of a deregistering target to unused | number | `15` | no |
-| health_check_enabled | A boolean flag to enable/disable the NLB health checks | bool | `true` | no |
-| health_check_interval | The duration in seconds in between health checks | number | `15` | no |
-| health_check_path | The destination for the health check request | string | `/` | no |
-| health_check_port | The port to send the health check request to (defaults to `traffic-port`) | number | `null` | no |
-| health_check_protocol | The protocol to use for the health check request | string | `null` | no |
-| health_check_threshold | The number of consecutive health checks successes required before considering an unhealthy target healthy, or failures required before considering a health target unhealthy | number | `2` | no |
-| internal | A boolean flag to determine whether the NLB should be internal | bool | `false` | no |
-| ip_address_type | The type of IP addresses used by the subnets for your load balancer. The possible values are `ipv4` and `dualstack`. | string | `ipv4` | no |
-| name | Name of the application | string | - | yes |
-| namespace | Namespace (e.g. `eg` or `cp`) | string | `` | no |
-| nlb_access_logs_s3_bucket_force_destroy | A boolean that indicates all objects should be deleted from the NLB access logs S3 bucket so that the bucket can be destroyed without error | bool | `false` | no |
-| stage | Stage (e.g. `prod`, `dev`, `staging`) | string | `` | no |
-| subnet_ids | A list of subnet IDs to associate with NLB | list(string) | - | yes |
-| tags | Additional tags (_e.g._ { BusinessUnit : ABC }) | map(string) | `<map>` | no |
-| target_group_additional_tags | The additional tags to apply to the default target group | map(string) | `<map>` | no |
-| target_group_name | The name for the default target group, uses a module label name if left empty | string | `` | no |
-| target_group_port | The port for the default target group | number | `80` | no |
-| target_group_target_type | The type (`instance`, `ip` or `lambda`) of targets that can be registered with the default target group | string | `ip` | no |
-| tcp_enabled | A boolean flag to enable/disable TCP listener | bool | `true` | no |
-| tcp_port | The port for the TCP listener | number | `80` | no |
-| tls_enabled | A boolean flag to enable/disable TLS listener | bool | `false` | no |
-| tls_port | The port for the TLS listener | number | `443` | no |
-| tls_ssl_policy | The name of the SSL Policy for the listener | string | `ELBSecurityPolicy-2016-08` | no |
-| udp_enabled | A boolean flag to enable/disable UDP listener | bool | `false` | no |
-| udp_port | The port for the UDP listener | number | `53` | no |
-| vpc_id | VPC ID to associate with NLB | string | - | yes |
+|------|-------------|------|---------|:--------:|
+| access\_logs\_enabled | A boolean flag to enable/disable access\_logs | `bool` | `true` | no |
+| access\_logs\_prefix | The S3 log bucket prefix | `string` | `""` | no |
+| access\_logs\_region | The region for the access\_logs S3 bucket | `string` | `"us-east-1"` | no |
+| attributes | Additional attributes (\_e.g.\_ "1") | `list(string)` | `[]` | no |
+| certificate\_arn | The ARN of the default SSL certificate for HTTPS listener | `string` | `""` | no |
+| cross\_zone\_load\_balancing\_enabled | A boolean flag to enable/disable cross zone load balancing | `bool` | `true` | no |
+| deletion\_protection\_enabled | A boolean flag to enable/disable deletion protection for NLB | `bool` | `false` | no |
+| delimiter | Delimiter between `namespace`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
+| deregistration\_delay | The amount of time to wait in seconds before changing the state of a deregistering target to unused | `number` | `15` | no |
+| enable\_glacier\_transition | Enables the transition of lb logs to AWS Glacier | `bool` | `true` | no |
+| expiration\_days | Number of days after which to expunge s3 logs | `number` | `90` | no |
+| glacier\_transition\_days | Number of days after which to move s3 logs to the glacier storage tier | `number` | `60` | no |
+| health\_check\_enabled | A boolean flag to enable/disable the NLB health checks | `bool` | `true` | no |
+| health\_check\_interval | The duration in seconds in between health checks | `number` | `15` | no |
+| health\_check\_path | The destination for the health check request | `string` | `"/"` | no |
+| health\_check\_port | The port to send the health check request to (defaults to `traffic-port`) | `number` | `null` | no |
+| health\_check\_protocol | The protocol to use for the health check request | `string` | `null` | no |
+| health\_check\_threshold | The number of consecutive health checks successes required before considering an unhealthy target healthy, or failures required before considering a health target unhealthy | `number` | `2` | no |
+| internal | A boolean flag to determine whether the NLB should be internal | `bool` | `false` | no |
+| ip\_address\_type | The type of IP addresses used by the subnets for your load balancer. The possible values are `ipv4` and `dualstack`. | `string` | `"ipv4"` | no |
+| lifecycle\_rule\_enabled | A boolean that indicates whether the s3 log bucket lifecycle rule should be enabled. | `bool` | `false` | no |
+| name | Name of the application | `string` | n/a | yes |
+| namespace | Namespace (e.g. `eg` or `cp`) | `string` | `""` | no |
+| nlb\_access\_logs\_s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the NLB access logs S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
+| noncurrent\_version\_expiration\_days | Specifies when noncurrent s3 log versions expire | `number` | `90` | no |
+| noncurrent\_version\_transition\_days | Specifies when noncurrent s3 log versions transition | `number` | `30` | no |
+| stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | `""` | no |
+| standard\_transition\_days | Number of days to persist logs in standard storage tier before moving to the infrequent access tier | `number` | `30` | no |
+| subnet\_ids | A list of subnet IDs to associate with NLB | `list(string)` | n/a | yes |
+| tags | Additional tags (\_e.g.\_ { BusinessUnit : ABC }) | `map(string)` | `{}` | no |
+| target\_group\_additional\_tags | The additional tags to apply to the default target group | `map(string)` | `{}` | no |
+| target\_group\_name | The name for the default target group, uses a module label name if left empty | `string` | `""` | no |
+| target\_group\_port | The port for the default target group | `number` | `80` | no |
+| target\_group\_target\_type | The type (`instance`, `ip` or `lambda`) of targets that can be registered with the default target group | `string` | `"ip"` | no |
+| tcp\_enabled | A boolean flag to enable/disable TCP listener | `bool` | `true` | no |
+| tcp\_port | The port for the TCP listener | `number` | `80` | no |
+| tls\_enabled | A boolean flag to enable/disable TLS listener | `bool` | `false` | no |
+| tls\_port | The port for the TLS listener | `number` | `443` | no |
+| tls\_ssl\_policy | The name of the SSL Policy for the listener | `string` | `"ELBSecurityPolicy-2016-08"` | no |
+| udp\_enabled | A boolean flag to enable/disable UDP listener | `bool` | `false` | no |
+| udp\_port | The port for the UDP listener | `number` | `53` | no |
+| vpc\_id | VPC ID to associate with NLB | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| access_logs_bucket_id | The S3 bucket ID for access logs |
-| default_listener_arn | The ARN of the default listener |
-| default_target_group_arn | The default target group ARN |
-| listener_arns | A list of all the listener ARNs |
-| nlb_arn | The ARN of the NLB |
-| nlb_arn_suffix | The ARN suffix of the NLB |
-| nlb_dns_name | DNS name of NLB |
-| nlb_name | The ARN suffix of the NLB |
-| nlb_zone_id | The ID of the zone which NLB is provisioned |
-| tls_listener_arn | The ARN of the TLS listener |
+| access\_logs\_bucket\_id | The S3 bucket ID for access logs |
+| default\_listener\_arn | The ARN of the default listener |
+| default\_target\_group\_arn | The default target group ARN |
+| listener\_arns | A list of all the listener ARNs |
+| nlb\_arn | The ARN of the NLB |
+| nlb\_arn\_suffix | The ARN suffix of the NLB |
+| nlb\_dns\_name | DNS name of NLB |
+| nlb\_name | The ARN suffix of the NLB |
+| nlb\_zone\_id | The ID of the zone which NLB is provisioned |
+| tls\_listener\_arn | The ARN of the TLS listener |
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -31,7 +31,7 @@
 | expiration\_days | Number of days after which to expunge s3 logs | `number` | `90` | no |
 | glacier\_transition\_days | Number of days after which to move s3 logs to the glacier storage tier | `number` | `60` | no |
 | health\_check\_enabled | A boolean flag to enable/disable the NLB health checks | `bool` | `true` | no |
-| health\_check\_interval | The duration in seconds in between health checks | `number` | `15` | no |
+| health\_check\_interval | The duration in seconds in between health checks | `number` | `10` | no |
 | health\_check\_path | The destination for the health check request | `string` | `"/"` | no |
 | health\_check\_port | The port to send the health check request to (defaults to `traffic-port`) | `number` | `null` | no |
 | health\_check\_protocol | The protocol to use for the health check request | `string` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,55 +1,78 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.0 |
+| aws | ~> 2.0 |
+| local | ~> 1.3 |
+| null | ~> 2.0 |
+| template | ~> 2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2.0 |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| access_logs_enabled | A boolean flag to enable/disable access_logs | bool | `true` | no |
-| access_logs_prefix | The S3 log bucket prefix | string | `` | no |
-| access_logs_region | The region for the access_logs S3 bucket | string | `us-east-1` | no |
-| attributes | Additional attributes (_e.g._ "1") | list(string) | `<list>` | no |
-| certificate_arn | The ARN of the default SSL certificate for HTTPS listener | string | `` | no |
-| cross_zone_load_balancing_enabled | A boolean flag to enable/disable cross zone load balancing | bool | `true` | no |
-| deletion_protection_enabled | A boolean flag to enable/disable deletion protection for NLB | bool | `false` | no |
-| delimiter | Delimiter between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
-| deregistration_delay | The amount of time to wait in seconds before changing the state of a deregistering target to unused | number | `15` | no |
-| health_check_enabled | A boolean flag to enable/disable the NLB health checks | bool | `true` | no |
-| health_check_interval | The duration in seconds in between health checks | number | `15` | no |
-| health_check_path | The destination for the health check request | string | `/` | no |
-| health_check_port | The port to send the health check request to (defaults to `traffic-port`) | number | `null` | no |
-| health_check_protocol | The protocol to use for the health check request | string | `null` | no |
-| health_check_threshold | The number of consecutive health checks successes required before considering an unhealthy target healthy, or failures required before considering a health target unhealthy | number | `2` | no |
-| internal | A boolean flag to determine whether the NLB should be internal | bool | `false` | no |
-| ip_address_type | The type of IP addresses used by the subnets for your load balancer. The possible values are `ipv4` and `dualstack`. | string | `ipv4` | no |
-| name | Name of the application | string | - | yes |
-| namespace | Namespace (e.g. `eg` or `cp`) | string | `` | no |
-| nlb_access_logs_s3_bucket_force_destroy | A boolean that indicates all objects should be deleted from the NLB access logs S3 bucket so that the bucket can be destroyed without error | bool | `false` | no |
-| stage | Stage (e.g. `prod`, `dev`, `staging`) | string | `` | no |
-| subnet_ids | A list of subnet IDs to associate with NLB | list(string) | - | yes |
-| tags | Additional tags (_e.g._ { BusinessUnit : ABC }) | map(string) | `<map>` | no |
-| target_group_additional_tags | The additional tags to apply to the default target group | map(string) | `<map>` | no |
-| target_group_name | The name for the default target group, uses a module label name if left empty | string | `` | no |
-| target_group_port | The port for the default target group | number | `80` | no |
-| target_group_target_type | The type (`instance`, `ip` or `lambda`) of targets that can be registered with the default target group | string | `ip` | no |
-| tcp_enabled | A boolean flag to enable/disable TCP listener | bool | `true` | no |
-| tcp_port | The port for the TCP listener | number | `80` | no |
-| tls_enabled | A boolean flag to enable/disable TLS listener | bool | `false` | no |
-| tls_port | The port for the TLS listener | number | `443` | no |
-| tls_ssl_policy | The name of the SSL Policy for the listener | string | `ELBSecurityPolicy-2016-08` | no |
-| udp_enabled | A boolean flag to enable/disable UDP listener | bool | `false` | no |
-| udp_port | The port for the UDP listener | number | `53` | no |
-| vpc_id | VPC ID to associate with NLB | string | - | yes |
+|------|-------------|------|---------|:--------:|
+| access\_logs\_enabled | A boolean flag to enable/disable access\_logs | `bool` | `true` | no |
+| access\_logs\_prefix | The S3 log bucket prefix | `string` | `""` | no |
+| access\_logs\_region | The region for the access\_logs S3 bucket | `string` | `"us-east-1"` | no |
+| attributes | Additional attributes (\_e.g.\_ "1") | `list(string)` | `[]` | no |
+| certificate\_arn | The ARN of the default SSL certificate for HTTPS listener | `string` | `""` | no |
+| cross\_zone\_load\_balancing\_enabled | A boolean flag to enable/disable cross zone load balancing | `bool` | `true` | no |
+| deletion\_protection\_enabled | A boolean flag to enable/disable deletion protection for NLB | `bool` | `false` | no |
+| delimiter | Delimiter between `namespace`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
+| deregistration\_delay | The amount of time to wait in seconds before changing the state of a deregistering target to unused | `number` | `15` | no |
+| enable\_glacier\_transition | Enables the transition of lb logs to AWS Glacier | `bool` | `true` | no |
+| expiration\_days | Number of days after which to expunge s3 logs | `number` | `90` | no |
+| glacier\_transition\_days | Number of days after which to move s3 logs to the glacier storage tier | `number` | `60` | no |
+| health\_check\_enabled | A boolean flag to enable/disable the NLB health checks | `bool` | `true` | no |
+| health\_check\_interval | The duration in seconds in between health checks | `number` | `15` | no |
+| health\_check\_path | The destination for the health check request | `string` | `"/"` | no |
+| health\_check\_port | The port to send the health check request to (defaults to `traffic-port`) | `number` | `null` | no |
+| health\_check\_protocol | The protocol to use for the health check request | `string` | `null` | no |
+| health\_check\_threshold | The number of consecutive health checks successes required before considering an unhealthy target healthy, or failures required before considering a health target unhealthy | `number` | `2` | no |
+| internal | A boolean flag to determine whether the NLB should be internal | `bool` | `false` | no |
+| ip\_address\_type | The type of IP addresses used by the subnets for your load balancer. The possible values are `ipv4` and `dualstack`. | `string` | `"ipv4"` | no |
+| lifecycle\_rule\_enabled | A boolean that indicates whether the s3 log bucket lifecycle rule should be enabled. | `bool` | `false` | no |
+| name | Name of the application | `string` | n/a | yes |
+| namespace | Namespace (e.g. `eg` or `cp`) | `string` | `""` | no |
+| nlb\_access\_logs\_s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the NLB access logs S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
+| noncurrent\_version\_expiration\_days | Specifies when noncurrent s3 log versions expire | `number` | `90` | no |
+| noncurrent\_version\_transition\_days | Specifies when noncurrent s3 log versions transition | `number` | `30` | no |
+| stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | `""` | no |
+| standard\_transition\_days | Number of days to persist logs in standard storage tier before moving to the infrequent access tier | `number` | `30` | no |
+| subnet\_ids | A list of subnet IDs to associate with NLB | `list(string)` | n/a | yes |
+| tags | Additional tags (\_e.g.\_ { BusinessUnit : ABC }) | `map(string)` | `{}` | no |
+| target\_group\_additional\_tags | The additional tags to apply to the default target group | `map(string)` | `{}` | no |
+| target\_group\_name | The name for the default target group, uses a module label name if left empty | `string` | `""` | no |
+| target\_group\_port | The port for the default target group | `number` | `80` | no |
+| target\_group\_target\_type | The type (`instance`, `ip` or `lambda`) of targets that can be registered with the default target group | `string` | `"ip"` | no |
+| tcp\_enabled | A boolean flag to enable/disable TCP listener | `bool` | `true` | no |
+| tcp\_port | The port for the TCP listener | `number` | `80` | no |
+| tls\_enabled | A boolean flag to enable/disable TLS listener | `bool` | `false` | no |
+| tls\_port | The port for the TLS listener | `number` | `443` | no |
+| tls\_ssl\_policy | The name of the SSL Policy for the listener | `string` | `"ELBSecurityPolicy-2016-08"` | no |
+| udp\_enabled | A boolean flag to enable/disable UDP listener | `bool` | `false` | no |
+| udp\_port | The port for the UDP listener | `number` | `53` | no |
+| vpc\_id | VPC ID to associate with NLB | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| access_logs_bucket_id | The S3 bucket ID for access logs |
-| default_listener_arn | The ARN of the default listener |
-| default_target_group_arn | The default target group ARN |
-| listener_arns | A list of all the listener ARNs |
-| nlb_arn | The ARN of the NLB |
-| nlb_arn_suffix | The ARN suffix of the NLB |
-| nlb_dns_name | DNS name of NLB |
-| nlb_name | The ARN suffix of the NLB |
-| nlb_zone_id | The ID of the zone which NLB is provisioned |
-| tls_listener_arn | The ARN of the TLS listener |
+| access\_logs\_bucket\_id | The S3 bucket ID for access logs |
+| default\_listener\_arn | The ARN of the default listener |
+| default\_target\_group\_arn | The default target group ARN |
+| listener\_arns | A list of all the listener ARNs |
+| nlb\_arn | The ARN of the NLB |
+| nlb\_arn\_suffix | The ARN suffix of the NLB |
+| nlb\_dns\_name | DNS name of NLB |
+| nlb\_name | The ARN suffix of the NLB |
+| nlb\_zone\_id | The ID of the zone which NLB is provisioned |
+| tls\_listener\_arn | The ARN of the TLS listener |
 

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -28,13 +28,11 @@ deletion_protection_enabled = false
 
 deregistration_delay = 15
 
-health_check_timeout = 10
-
-health_check_healthy_threshold = 2
-
-health_check_unhealthy_threshold = 2
+health_check_threshold = 2
 
 health_check_interval = 15
+
+health_check_protocol = "HTTP"
 
 target_group_port = 80
 

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -30,7 +30,7 @@ deregistration_delay = 15
 
 health_check_threshold = 2
 
-health_check_interval = 15
+health_check_interval = 10
 
 health_check_protocol = "HTTP"
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.8.1"
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.14.0"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -14,7 +14,7 @@ module "vpc" {
 }
 
 module "subnets" {
-  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.16.1"
+  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.19.0"
   availability_zones   = var.availability_zones
   namespace            = var.namespace
   stage                = var.stage
@@ -47,10 +47,7 @@ module "nlb" {
   ip_address_type                         = var.ip_address_type
   deletion_protection_enabled             = var.deletion_protection_enabled
   deregistration_delay                    = var.deregistration_delay
-  health_check_path                       = var.health_check_path
-  health_check_timeout                    = var.health_check_timeout
-  health_check_healthy_threshold          = var.health_check_healthy_threshold
-  health_check_unhealthy_threshold        = var.health_check_unhealthy_threshold
+  health_check_threshold                  = var.health_check_threshold
   health_check_interval                   = var.health_check_interval
   target_group_port                       = var.target_group_port
   target_group_target_type                = var.target_group_target_type

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -38,11 +38,6 @@ output "nlb_zone_id" {
   value       = module.nlb.nlb_zone_id
 }
 
-output "security_group_id" {
-  description = "The security group ID of the NLB"
-  value       = module.nlb.security_group_id
-}
-
 output "default_target_group_arn" {
   description = "The default target group ARN"
   value       = module.nlb.default_target_group_arn

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -86,19 +86,14 @@ variable "deregistration_delay" {
   description = "The amount of time to wait in seconds before changing the state of a deregistering target to unused"
 }
 
-variable "health_check_timeout" {
-  type        = number
-  description = "The amount of time to wait in seconds before failing a health check request"
-}
-
-variable "health_check_healthy_threshold" {
+variable "health_check_threshold" {
   type        = number
   description = "The number of consecutive health checks successes required before considering an unhealthy target healthy"
 }
 
-variable "health_check_unhealthy_threshold" {
-  type        = number
-  description = "The number of consecutive health check failures required before considering the target unhealthy"
+variable "health_check_protocol" {
+  type        = string
+  description = "The protocol to use for the health check request"
 }
 
 variable "health_check_interval" {

--- a/main.tf
+++ b/main.tf
@@ -18,16 +18,23 @@ module "default_label" {
 }
 
 module "access_logs" {
-  source        = "git::https://github.com/cloudposse/terraform-aws-lb-s3-bucket.git?ref=tags/0.3.0"
-  name          = var.name
-  namespace     = var.namespace
-  stage         = var.stage
-  attributes    = compact(concat(var.attributes, ["nlb", "access", "logs"]))
-  delimiter     = var.delimiter
-  tags          = var.tags
-  region        = var.access_logs_region
-  force_destroy = var.nlb_access_logs_s3_bucket_force_destroy
-  enabled       = false # Cannot apparently use encryption with S3 logs for NLB, even if using AES256. See https://github.com/cloudposse/terraform-aws-lb-s3-bucket/issues/9 for discussion.
+  source                             = "git::https://github.com/cloudposse/terraform-aws-lb-s3-bucket.git?ref=tags/0.4.0"
+  name                               = var.name
+  namespace                          = var.namespace
+  stage                              = var.stage
+  attributes                         = compact(concat(var.attributes, ["nlb", "access", "logs"]))
+  delimiter                          = var.delimiter
+  tags                               = var.tags
+  region                             = var.access_logs_region
+  lifecycle_rule_enabled             = var.lifecycle_rule_enabled
+  enable_glacier_transition          = var.enable_glacier_transition
+  expiration_days                    = var.expiration_days
+  glacier_transition_days            = var.glacier_transition_days
+  noncurrent_version_expiration_days = var.noncurrent_version_expiration_days
+  noncurrent_version_transition_days = var.noncurrent_version_transition_days
+  standard_transition_days           = var.standard_transition_days
+  force_destroy                      = var.nlb_access_logs_s3_bucket_force_destroy
+  enabled                            = false # Cannot apparently use encryption with S3 logs for NLB, even if using AES256. See https://github.com/cloudposse/terraform-aws-lb-s3-bucket/issues/9 for discussion.
 }
 
 resource "aws_lb" "default" {

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -55,10 +55,10 @@ func TestExamplesComplete(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	defaultTargetGroupArn := terraform.Output(t, terraformOptions, "default_target_group_arn")
 	// Verify we're getting back the outputs we expect
-	assert.Contains(t, defaultTargetGroupArn, "arn:aws:elasticloadbalancing:us-east-2:126450723953:targetgroup/eg-test-nlb-default")
+	assert.Contains(t, defaultTargetGroupArn, ":targetgroup/eg-test-nlb-default")
 
 	// Run `terraform output` to get the value of an output variable
 	defaultListenerArn := terraform.Output(t, terraformOptions, "default_listener_arn")
 	// Verify we're getting back the outputs we expect
-	assert.Contains(t, defaultListenerArn, "arn:aws:elasticloadbalancing:us-east-2:126450723953:listener/app/eg-test-nlb")
+	assert.Contains(t, defaultListenerArn, ":listener/net/eg-test-nlb")
 }

--- a/variables.tf
+++ b/variables.tf
@@ -195,7 +195,7 @@ variable "health_check_threshold" {
 
 variable "health_check_interval" {
   type        = number
-  default     = 15
+  default     = 10
   description = "The duration in seconds in between health checks"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -204,3 +204,45 @@ variable "nlb_access_logs_s3_bucket_force_destroy" {
   default     = false
   description = "A boolean that indicates all objects should be deleted from the NLB access logs S3 bucket so that the bucket can be destroyed without error"
 }
+
+variable "lifecycle_rule_enabled" {
+  type        = bool
+  description = "A boolean that indicates whether the s3 log bucket lifecycle rule should be enabled."
+  default     = false
+}
+
+variable "enable_glacier_transition" {
+  type        = bool
+  description = "Enables the transition of lb logs to AWS Glacier"
+  default     = true
+}
+
+variable "glacier_transition_days" {
+  type        = number
+  description = "Number of days after which to move s3 logs to the glacier storage tier"
+  default     = 60
+}
+
+variable "expiration_days" {
+  type        = number
+  description = "Number of days after which to expunge s3 logs"
+  default     = 90
+}
+
+variable "noncurrent_version_expiration_days" {
+  type        = number
+  description = "Specifies when noncurrent s3 log versions expire"
+  default     = 90
+}
+
+variable "noncurrent_version_transition_days" {
+  type        = number
+  description = "Specifies when noncurrent s3 log versions transition"
+  default     = 30
+}
+
+variable "standard_transition_days" {
+  type        = number
+  description = "Number of days to persist logs in standard storage tier before moving to the infrequent access tier"
+  default     = 30
+}


### PR DESCRIPTION
## what
* expose s3 lifecycle options for access logs

## why
* be consistent across alb/nlb modules

## references
* https://github.com/cloudposse/terraform-aws-alb/pull/44 
