### PR TITLE
Update access_logs module for TF 0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -227,6 +228,7 @@ Available targets:
 | nlb\_zone\_id | The ID of the zone which NLB is provisioned |
 | tls\_listener\_arn | The ARN of the TLS listener |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -76,3 +77,4 @@
 | nlb\_zone\_id | The ID of the zone which NLB is provisioned |
 | tls\_listener\_arn | The ARN of the TLS listener |
 
+<!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ module "default_label" {
 }
 
 module "access_logs" {
-  source                             = "git::https://github.com/cloudposse/terraform-aws-lb-s3-bucket.git?ref=tags/0.4.0"
+  source                             = "git::https://github.com/cloudposse/terraform-aws-lb-s3-bucket.git?ref=tags/0.7.0"
   name                               = var.name
   namespace                          = var.namespace
   stage                              = var.stage


### PR DESCRIPTION
## what
* Fix for TF 0.13

## why
* The access_logs module only supports TF 0.12

## references
* Issue #5 

