### PR TITLE
reintroduce support for access logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <!-- markdownlint-disable -->
 # terraform-aws-nlb [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-aws-nlb.svg)](https://github.com/cloudposse/terraform-aws-nlb/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
 <!-- markdownlint-restore -->
@@ -29,7 +30,6 @@
 
 Terraform module to create an NLB and a default NLB target and related security groups.
 
-
 ---
 
 This project is part of our comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps.
@@ -60,7 +60,6 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 
 
 
-
 ## Security & Compliance [<img src="https://cloudposse.com/wp-content/uploads/2020/11/bridgecrew.svg" width="250" align="right" />](https://bridgecrew.io/)
 
 Security scanning is graciously provided by Bridgecrew. Bridgecrew is the leading fully hosted, cloud-native solution providing continuous Terraform security and compliance.
@@ -80,19 +79,11 @@ Security scanning is graciously provided by Bridgecrew. Bridgecrew is the leadin
 
 
 
-## Usage
 
 
-**IMPORTANT:** We do not pin modules to versions in our examples because of the
-difficulty of keeping the versions in the documentation in sync with the latest released versions.
-We highly recommend that in your code you pin the version to the exact version you are
-using so that your infrastructure remains stable, and update versions in a
-systematic way so that they do not catch you by surprise.
 
-Also, because of a bug in the Terraform registry ([hashicorp/terraform#21417](https://github.com/hashicorp/terraform/issues/21417)),
-the registry shows many of our inputs as required when in fact they are optional.
-The table below correctly indicates which inputs are required.
 
+## Examples
 
 For a complete example, see [examples/complete](examples/complete).
 
@@ -104,41 +95,37 @@ For automated test of the complete example using `bats` and `Terratest`, see [te
   }
 
   module "vpc" {
-    source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.8.1"
-    namespace  = var.namespace
-    stage      = var.stage
-    name       = var.name
-    delimiter  = var.delimiter
-    attributes = var.attributes
+    source     = "cloudposse/vpc/aws"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version     = "x.x.x"
+
     cidr_block = var.vpc_cidr_block
-    tags       = var.tags
+
+    context = module.this.context
+    namespace = "eg"
+
   }
 
   module "subnets" {
-    source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.16.1"
+    source     = "cloudposse/dynamic-subnets/aws"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version     = "x.x.x"
+
     availability_zones   = var.availability_zones
-    namespace            = var.namespace
-    stage                = var.stage
-    name                 = var.name
-    attributes           = var.attributes
-    delimiter            = var.delimiter
     vpc_id               = module.vpc.vpc_id
     igw_id               = module.vpc.igw_id
     cidr_block           = module.vpc.vpc_cidr_block
     nat_gateway_enabled  = false
     nat_instance_enabled = false
-    tags                 = var.tags
+
+    context = module.this.context
+    namespace = "eg"
   }
 
   module "nlb" {
     source = "cloudposse/nlb/aws"
     # Cloud Posse recommends pinning every module to a specific version
     # version = "x.x.x"
-    namespace                               = var.namespace
-    stage                                   = var.stage
-    name                                    = var.name
-    attributes                              = var.attributes
-    delimiter                               = var.delimiter
     vpc_id                                  = module.vpc.vpc_id
     subnet_ids                              = module.subnets.public_subnet_ids
     internal                                = var.internal
@@ -157,12 +144,10 @@ For automated test of the complete example using `bats` and `Terratest`, see [te
     health_check_interval                   = var.health_check_interval
     target_group_port                       = var.target_group_port
     target_group_target_type                = var.target_group_target_type
-    tags                                    = var.tags
+    
+    context = module.this.context
   }
 ```
-
-
-
 
 
 
@@ -183,90 +168,121 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0 |
-| aws | >= 2.0 |
-| local | >= 1.3 |
-| null | >= 2.0 |
-| template | >= 2.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
+| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_access_logs"></a> [access\_logs](#module\_access\_logs) | cloudposse/lb-s3-bucket/aws | 0.11.4 |
+| <a name="module_default_target_group_label"></a> [default\_target\_group\_label](#module\_default\_target\_group\_label) | cloudposse/label/null | 0.24.1 |
+| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_lb.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
+| [aws_lb_listener.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_listener.tls](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_target_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| access\_logs\_enabled | A boolean flag to enable/disable access\_logs | `bool` | `true` | no |
-| access\_logs\_prefix | The S3 log bucket prefix | `string` | `""` | no |
-| access\_logs\_region | The region for the access\_logs S3 bucket | `string` | `"us-east-1"` | no |
-| additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
-| attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
-| certificate\_arn | The ARN of the default SSL certificate for HTTPS listener | `string` | `""` | no |
-| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
-| cross\_zone\_load\_balancing\_enabled | A boolean flag to enable/disable cross zone load balancing | `bool` | `true` | no |
-| deletion\_protection\_enabled | A boolean flag to enable/disable deletion protection for NLB | `bool` | `false` | no |
-| delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
-| deregistration\_delay | The amount of time to wait in seconds before changing the state of a deregistering target to unused | `number` | `15` | no |
-| enable\_glacier\_transition | Enables the transition of lb logs to AWS Glacier | `bool` | `true` | no |
-| enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
-| environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
-| expiration\_days | Number of days after which to expunge s3 logs | `number` | `90` | no |
-| glacier\_transition\_days | Number of days after which to move s3 logs to the glacier storage tier | `number` | `60` | no |
-| health\_check\_enabled | A boolean flag to enable/disable the NLB health checks | `bool` | `true` | no |
-| health\_check\_interval | The duration in seconds in between health checks | `number` | `10` | no |
-| health\_check\_path | The destination for the health check request | `string` | `"/"` | no |
-| health\_check\_port | The port to send the health check request to (defaults to `traffic-port`) | `number` | `null` | no |
-| health\_check\_protocol | The protocol to use for the health check request | `string` | `null` | no |
-| health\_check\_threshold | The number of consecutive health checks successes required before considering an unhealthy target healthy, or failures required before considering a health target unhealthy | `number` | `2` | no |
-| id\_length\_limit | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
-| internal | A boolean flag to determine whether the NLB should be internal | `bool` | `false` | no |
-| ip\_address\_type | The type of IP addresses used by the subnets for your load balancer. The possible values are `ipv4` and `dualstack`. | `string` | `"ipv4"` | no |
-| label\_key\_case | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
-| label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
-| label\_value\_case | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
-| lifecycle\_rule\_enabled | A boolean that indicates whether the s3 log bucket lifecycle rule should be enabled. | `bool` | `false` | no |
-| name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
-| namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
-| nlb\_access\_logs\_s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the NLB access logs S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
-| noncurrent\_version\_expiration\_days | Specifies when noncurrent s3 log versions expire | `number` | `90` | no |
-| noncurrent\_version\_transition\_days | Specifies when noncurrent s3 log versions transition | `number` | `30` | no |
-| regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
-| stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
-| standard\_transition\_days | Number of days to persist logs in standard storage tier before moving to the infrequent access tier | `number` | `30` | no |
-| subnet\_ids | A list of subnet IDs to associate with NLB | `list(string)` | n/a | yes |
-| tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
-| target\_group\_additional\_tags | The additional tags to apply to the default target group | `map(string)` | `{}` | no |
-| target\_group\_name | The name for the default target group, uses a module label name if left empty | `string` | `""` | no |
-| target\_group\_port | The port for the default target group | `number` | `80` | no |
-| target\_group\_target\_type | The type (`instance`, `ip` or `lambda`) of targets that can be registered with the default target group | `string` | `"ip"` | no |
-| tcp\_enabled | A boolean flag to enable/disable TCP listener | `bool` | `true` | no |
-| tcp\_port | The port for the TCP listener | `number` | `80` | no |
-| tls\_enabled | A boolean flag to enable/disable TLS listener | `bool` | `false` | no |
-| tls\_port | The port for the TLS listener | `number` | `443` | no |
-| tls\_ssl\_policy | The name of the SSL Policy for the listener | `string` | `"ELBSecurityPolicy-2016-08"` | no |
-| udp\_enabled | A boolean flag to enable/disable UDP listener | `bool` | `false` | no |
-| udp\_port | The port for the UDP listener | `number` | `53` | no |
-| vpc\_id | VPC ID to associate with NLB | `string` | n/a | yes |
+| <a name="input_access_logs_enabled"></a> [access\_logs\_enabled](#input\_access\_logs\_enabled) | A boolean flag to enable/disable access\_logs | `bool` | `true` | no |
+| <a name="input_access_logs_prefix"></a> [access\_logs\_prefix](#input\_access\_logs\_prefix) | The S3 log bucket prefix | `string` | `""` | no |
+| <a name="input_access_logs_s3_bucket_id"></a> [access\_logs\_s3\_bucket\_id](#input\_access\_logs\_s3\_bucket\_id) | An external S3 Bucket name to store access logs in. If specified, no logging bucket will be created. | `string` | `null` | no |
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
+| <a name="input_certificate_arn"></a> [certificate\_arn](#input\_certificate\_arn) | The ARN of the default SSL certificate for HTTPS listener | `string` | `""` | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| <a name="input_cross_zone_load_balancing_enabled"></a> [cross\_zone\_load\_balancing\_enabled](#input\_cross\_zone\_load\_balancing\_enabled) | A boolean flag to enable/disable cross zone load balancing | `bool` | `true` | no |
+| <a name="input_deletion_protection_enabled"></a> [deletion\_protection\_enabled](#input\_deletion\_protection\_enabled) | A boolean flag to enable/disable deletion protection for NLB | `bool` | `false` | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_deregistration_delay"></a> [deregistration\_delay](#input\_deregistration\_delay) | The amount of time to wait in seconds before changing the state of a deregistering target to unused | `number` | `15` | no |
+| <a name="input_enable_glacier_transition"></a> [enable\_glacier\_transition](#input\_enable\_glacier\_transition) | Enables the transition of lb logs to AWS Glacier | `bool` | `true` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_expiration_days"></a> [expiration\_days](#input\_expiration\_days) | Number of days after which to expunge s3 logs | `number` | `90` | no |
+| <a name="input_glacier_transition_days"></a> [glacier\_transition\_days](#input\_glacier\_transition\_days) | Number of days after which to move s3 logs to the glacier storage tier | `number` | `60` | no |
+| <a name="input_health_check_enabled"></a> [health\_check\_enabled](#input\_health\_check\_enabled) | A boolean flag to enable/disable the NLB health checks | `bool` | `true` | no |
+| <a name="input_health_check_interval"></a> [health\_check\_interval](#input\_health\_check\_interval) | The duration in seconds in between health checks | `number` | `10` | no |
+| <a name="input_health_check_path"></a> [health\_check\_path](#input\_health\_check\_path) | The destination for the health check request | `string` | `"/"` | no |
+| <a name="input_health_check_port"></a> [health\_check\_port](#input\_health\_check\_port) | The port to send the health check request to (defaults to `traffic-port`) | `number` | `null` | no |
+| <a name="input_health_check_protocol"></a> [health\_check\_protocol](#input\_health\_check\_protocol) | The protocol to use for the health check request | `string` | `null` | no |
+| <a name="input_health_check_threshold"></a> [health\_check\_threshold](#input\_health\_check\_threshold) | The number of consecutive health checks successes required before considering an unhealthy target healthy, or failures required before considering a health target unhealthy | `number` | `2` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_internal"></a> [internal](#input\_internal) | A boolean flag to determine whether the NLB should be internal | `bool` | `false` | no |
+| <a name="input_ip_address_type"></a> [ip\_address\_type](#input\_ip\_address\_type) | The type of IP addresses used by the subnets for your load balancer. The possible values are `ipv4` and `dualstack`. | `string` | `"ipv4"` | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_lifecycle_rule_enabled"></a> [lifecycle\_rule\_enabled](#input\_lifecycle\_rule\_enabled) | A boolean that indicates whether the s3 log bucket lifecycle rule should be enabled. | `bool` | `false` | no |
+| <a name="input_name"></a> [name](#input\_name) | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
+| <a name="input_nlb_access_logs_s3_bucket_force_destroy"></a> [nlb\_access\_logs\_s3\_bucket\_force\_destroy](#input\_nlb\_access\_logs\_s3\_bucket\_force\_destroy) | A boolean that indicates all objects should be deleted from the NLB access logs S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
+| <a name="input_noncurrent_version_expiration_days"></a> [noncurrent\_version\_expiration\_days](#input\_noncurrent\_version\_expiration\_days) | Specifies when noncurrent s3 log versions expire | `number` | `90` | no |
+| <a name="input_noncurrent_version_transition_days"></a> [noncurrent\_version\_transition\_days](#input\_noncurrent\_version\_transition\_days) | Specifies when noncurrent s3 log versions transition | `number` | `30` | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_standard_transition_days"></a> [standard\_transition\_days](#input\_standard\_transition\_days) | Number of days to persist logs in standard storage tier before moving to the infrequent access tier | `number` | `30` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of subnet IDs to associate with NLB | `list(string)` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
+| <a name="input_target_group_additional_tags"></a> [target\_group\_additional\_tags](#input\_target\_group\_additional\_tags) | The additional tags to apply to the default target group | `map(string)` | `{}` | no |
+| <a name="input_target_group_name"></a> [target\_group\_name](#input\_target\_group\_name) | The name for the default target group, uses a module label name if left empty | `string` | `""` | no |
+| <a name="input_target_group_port"></a> [target\_group\_port](#input\_target\_group\_port) | The port for the default target group | `number` | `80` | no |
+| <a name="input_target_group_target_type"></a> [target\_group\_target\_type](#input\_target\_group\_target\_type) | The type (`instance`, `ip` or `lambda`) of targets that can be registered with the default target group | `string` | `"ip"` | no |
+| <a name="input_tcp_enabled"></a> [tcp\_enabled](#input\_tcp\_enabled) | A boolean flag to enable/disable TCP listener | `bool` | `true` | no |
+| <a name="input_tcp_port"></a> [tcp\_port](#input\_tcp\_port) | The port for the TCP listener | `number` | `80` | no |
+| <a name="input_tls_enabled"></a> [tls\_enabled](#input\_tls\_enabled) | A boolean flag to enable/disable TLS listener | `bool` | `false` | no |
+| <a name="input_tls_port"></a> [tls\_port](#input\_tls\_port) | The port for the TLS listener | `number` | `443` | no |
+| <a name="input_tls_ssl_policy"></a> [tls\_ssl\_policy](#input\_tls\_ssl\_policy) | The name of the SSL Policy for the listener | `string` | `"ELBSecurityPolicy-2016-08"` | no |
+| <a name="input_udp_enabled"></a> [udp\_enabled](#input\_udp\_enabled) | A boolean flag to enable/disable UDP listener | `bool` | `false` | no |
+| <a name="input_udp_port"></a> [udp\_port](#input\_udp\_port) | The port for the UDP listener | `number` | `53` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID to associate with NLB | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| access\_logs\_bucket\_id | The S3 bucket ID for access logs |
-| default\_listener\_arn | The ARN of the default listener |
-| default\_target\_group\_arn | The default target group ARN |
-| listener\_arns | A list of all the listener ARNs |
-| nlb\_arn | The ARN of the NLB |
-| nlb\_arn\_suffix | The ARN suffix of the NLB |
-| nlb\_dns\_name | DNS name of NLB |
-| nlb\_name | The ARN suffix of the NLB |
-| nlb\_zone\_id | The ID of the zone which NLB is provisioned |
-| tls\_listener\_arn | The ARN of the TLS listener |
-
+| <a name="output_access_logs_bucket_id"></a> [access\_logs\_bucket\_id](#output\_access\_logs\_bucket\_id) | The S3 bucket ID for access logs |
+| <a name="output_default_listener_arn"></a> [default\_listener\_arn](#output\_default\_listener\_arn) | The ARN of the default listener |
+| <a name="output_default_target_group_arn"></a> [default\_target\_group\_arn](#output\_default\_target\_group\_arn) | The default target group ARN |
+| <a name="output_listener_arns"></a> [listener\_arns](#output\_listener\_arns) | A list of all the listener ARNs |
+| <a name="output_nlb_arn"></a> [nlb\_arn](#output\_nlb\_arn) | The ARN of the NLB |
+| <a name="output_nlb_arn_suffix"></a> [nlb\_arn\_suffix](#output\_nlb\_arn\_suffix) | The ARN suffix of the NLB |
+| <a name="output_nlb_dns_name"></a> [nlb\_dns\_name](#output\_nlb\_dns\_name) | DNS name of NLB |
+| <a name="output_nlb_name"></a> [nlb\_name](#output\_nlb\_name) | The ARN suffix of the NLB |
+| <a name="output_nlb_zone_id"></a> [nlb\_zone\_id](#output\_nlb\_zone\_id) | The ID of the zone which NLB is provisioned |
+| <a name="output_tls_listener_arn"></a> [tls\_listener\_arn](#output\_tls\_listener\_arn) | The ARN of the TLS listener |
 <!-- markdownlint-restore -->
+
+
+
+## Share the Love
+
+Like this project? Please give it a ★ on [our GitHub](https://github.com/cloudposse/terraform-aws-nlb)! (it helps us **a lot**)
+
+Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
+
+
+## Related Projects
+
+Check out these related projects.
+
+- [terraform-aws-alb](https://github.com/cloudposse/terraform-aws-alb) - Terraform module to create an ALB, default ALB listener(s), and a default ALB target and related security groups.
 
 
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Available targets:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_access_logs"></a> [access\_logs](#module\_access\_logs) | cloudposse/lb-s3-bucket/aws | 0.11.4 |
+| <a name="module_access_logs"></a> [access\_logs](#module\_access\_logs) | cloudposse/lb-s3-bucket/aws | 0.12.0 |
 | <a name="module_default_target_group_label"></a> [default\_target\_group\_label](#module\_default\_target\_group\_label) | cloudposse/label/null | 0.24.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ For automated test of the complete example using `bats` and `Terratest`, see [te
     tcp_enabled                             = var.tcp_enabled
     access_logs_enabled                     = var.access_logs_enabled
     nlb_access_logs_s3_bucket_force_destroy = var.nlb_access_logs_s3_bucket_force_destroy
-    access_logs_region                      = var.access_logs_region
     cross_zone_load_balancing_enabled       = var.cross_zone_load_balancing_enabled
     idle_timeout                            = var.idle_timeout
     ip_address_type                         = var.ip_address_type

--- a/README.md
+++ b/README.md
@@ -79,11 +79,19 @@ Security scanning is graciously provided by Bridgecrew. Bridgecrew is the leadin
 
 
 
+## Usage
 
 
+**IMPORTANT:** We do not pin modules to versions in our examples because of the
+difficulty of keeping the versions in the documentation in sync with the latest released versions.
+We highly recommend that in your code you pin the version to the exact version you are
+using so that your infrastructure remains stable, and update versions in a
+systematic way so that they do not catch you by surprise.
 
+Also, because of a bug in the Terraform registry ([hashicorp/terraform#21417](https://github.com/hashicorp/terraform/issues/21417)),
+the registry shows many of our inputs as required when in fact they are optional.
+The table below correctly indicates which inputs are required.
 
-## Examples
 
 For a complete example, see [examples/complete](examples/complete).
 
@@ -148,6 +156,9 @@ For automated test of the complete example using `bats` and `Terratest`, see [te
     context = module.this.context
   }
 ```
+
+
+
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -16,7 +16,7 @@ related:
     url: https://github.com/cloudposse/terraform-aws-alb
 description: Terraform module to create an NLB and a default NLB target and related
   security groups.
-examples: |-
+usage: |-
   For a complete example, see [examples/complete](examples/complete).
 
   For automated test of the complete example using `bats` and `Terratest`, see [test](test).

--- a/README.yaml
+++ b/README.yaml
@@ -62,7 +62,6 @@ usage: |-
       tcp_enabled                             = var.tcp_enabled
       access_logs_enabled                     = var.access_logs_enabled
       nlb_access_logs_s3_bucket_force_destroy = var.nlb_access_logs_s3_bucket_force_destroy
-      access_logs_region                      = var.access_logs_region
       cross_zone_load_balancing_enabled       = var.cross_zone_load_balancing_enabled
       idle_timeout                            = var.idle_timeout
       ip_address_type                         = var.ip_address_type

--- a/README.yaml
+++ b/README.yaml
@@ -8,9 +8,15 @@ badges:
 - name: Slack Community
   image: https://slack.cloudposse.com/badge.svg
   url: https://slack.cloudposse.com
+related:
+  - name: terraform-aws-alb
+    description:
+      Terraform module to create an ALB, default ALB listener(s), and a default ALB 
+      target and related security groups.
+    url: https://github.com/cloudposse/terraform-aws-alb
 description: Terraform module to create an NLB and a default NLB target and related
   security groups.
-usage: |-
+examples: |-
   For a complete example, see [examples/complete](examples/complete).
 
   For automated test of the complete example using `bats` and `Terratest`, see [test](test).
@@ -21,41 +27,37 @@ usage: |-
     }
 
     module "vpc" {
-      source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.8.1"
-      namespace  = var.namespace
-      stage      = var.stage
-      name       = var.name
-      delimiter  = var.delimiter
-      attributes = var.attributes
+      source     = "cloudposse/vpc/aws"
+      # Cloud Posse recommends pinning every module to a specific version
+      # version     = "x.x.x"
+
       cidr_block = var.vpc_cidr_block
-      tags       = var.tags
+
+      context = module.this.context
+      namespace = "eg"
+
     }
 
     module "subnets" {
-      source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.16.1"
+      source     = "cloudposse/dynamic-subnets/aws"
+      # Cloud Posse recommends pinning every module to a specific version
+      # version     = "x.x.x"
+
       availability_zones   = var.availability_zones
-      namespace            = var.namespace
-      stage                = var.stage
-      name                 = var.name
-      attributes           = var.attributes
-      delimiter            = var.delimiter
       vpc_id               = module.vpc.vpc_id
       igw_id               = module.vpc.igw_id
       cidr_block           = module.vpc.vpc_cidr_block
       nat_gateway_enabled  = false
       nat_instance_enabled = false
-      tags                 = var.tags
+
+      context = module.this.context
+      namespace = "eg"
     }
 
     module "nlb" {
       source = "cloudposse/nlb/aws"
       # Cloud Posse recommends pinning every module to a specific version
       # version = "x.x.x"
-      namespace                               = var.namespace
-      stage                                   = var.stage
-      name                                    = var.name
-      attributes                              = var.attributes
-      delimiter                               = var.delimiter
       vpc_id                                  = module.vpc.vpc_id
       subnet_ids                              = module.subnets.public_subnet_ids
       internal                                = var.internal
@@ -74,7 +76,8 @@ usage: |-
       health_check_interval                   = var.health_check_interval
       target_group_port                       = var.target_group_port
       target_group_target_type                = var.target_group_target_type
-      tags                                    = var.tags
+      
+      context = module.this.context
     }
   ```
 include:

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -19,7 +19,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_access_logs"></a> [access\_logs](#module\_access\_logs) | cloudposse/lb-s3-bucket/aws | 0.11.4 |
+| <a name="module_access_logs"></a> [access\_logs](#module\_access\_logs) | cloudposse/lb-s3-bucket/aws | 0.12.0 |
 | <a name="module_default_target_group_label"></a> [default\_target\_group\_label](#module\_default\_target\_group\_label) | cloudposse/label/null | 0.24.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,87 +3,103 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0 |
-| aws | >= 2.0 |
-| local | >= 1.3 |
-| null | >= 2.0 |
-| template | >= 2.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
+| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_access_logs"></a> [access\_logs](#module\_access\_logs) | cloudposse/lb-s3-bucket/aws | 0.11.4 |
+| <a name="module_default_target_group_label"></a> [default\_target\_group\_label](#module\_default\_target\_group\_label) | cloudposse/label/null | 0.24.1 |
+| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_lb.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
+| [aws_lb_listener.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_listener.tls](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_target_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| access\_logs\_enabled | A boolean flag to enable/disable access\_logs | `bool` | `true` | no |
-| access\_logs\_prefix | The S3 log bucket prefix | `string` | `""` | no |
-| access\_logs\_region | The region for the access\_logs S3 bucket | `string` | `"us-east-1"` | no |
-| additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
-| attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
-| certificate\_arn | The ARN of the default SSL certificate for HTTPS listener | `string` | `""` | no |
-| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
-| cross\_zone\_load\_balancing\_enabled | A boolean flag to enable/disable cross zone load balancing | `bool` | `true` | no |
-| deletion\_protection\_enabled | A boolean flag to enable/disable deletion protection for NLB | `bool` | `false` | no |
-| delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
-| deregistration\_delay | The amount of time to wait in seconds before changing the state of a deregistering target to unused | `number` | `15` | no |
-| enable\_glacier\_transition | Enables the transition of lb logs to AWS Glacier | `bool` | `true` | no |
-| enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
-| environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
-| expiration\_days | Number of days after which to expunge s3 logs | `number` | `90` | no |
-| glacier\_transition\_days | Number of days after which to move s3 logs to the glacier storage tier | `number` | `60` | no |
-| health\_check\_enabled | A boolean flag to enable/disable the NLB health checks | `bool` | `true` | no |
-| health\_check\_interval | The duration in seconds in between health checks | `number` | `10` | no |
-| health\_check\_path | The destination for the health check request | `string` | `"/"` | no |
-| health\_check\_port | The port to send the health check request to (defaults to `traffic-port`) | `number` | `null` | no |
-| health\_check\_protocol | The protocol to use for the health check request | `string` | `null` | no |
-| health\_check\_threshold | The number of consecutive health checks successes required before considering an unhealthy target healthy, or failures required before considering a health target unhealthy | `number` | `2` | no |
-| id\_length\_limit | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
-| internal | A boolean flag to determine whether the NLB should be internal | `bool` | `false` | no |
-| ip\_address\_type | The type of IP addresses used by the subnets for your load balancer. The possible values are `ipv4` and `dualstack`. | `string` | `"ipv4"` | no |
-| label\_key\_case | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
-| label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
-| label\_value\_case | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
-| lifecycle\_rule\_enabled | A boolean that indicates whether the s3 log bucket lifecycle rule should be enabled. | `bool` | `false` | no |
-| name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
-| namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
-| nlb\_access\_logs\_s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the NLB access logs S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
-| noncurrent\_version\_expiration\_days | Specifies when noncurrent s3 log versions expire | `number` | `90` | no |
-| noncurrent\_version\_transition\_days | Specifies when noncurrent s3 log versions transition | `number` | `30` | no |
-| regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
-| stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
-| standard\_transition\_days | Number of days to persist logs in standard storage tier before moving to the infrequent access tier | `number` | `30` | no |
-| subnet\_ids | A list of subnet IDs to associate with NLB | `list(string)` | n/a | yes |
-| tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
-| target\_group\_additional\_tags | The additional tags to apply to the default target group | `map(string)` | `{}` | no |
-| target\_group\_name | The name for the default target group, uses a module label name if left empty | `string` | `""` | no |
-| target\_group\_port | The port for the default target group | `number` | `80` | no |
-| target\_group\_target\_type | The type (`instance`, `ip` or `lambda`) of targets that can be registered with the default target group | `string` | `"ip"` | no |
-| tcp\_enabled | A boolean flag to enable/disable TCP listener | `bool` | `true` | no |
-| tcp\_port | The port for the TCP listener | `number` | `80` | no |
-| tls\_enabled | A boolean flag to enable/disable TLS listener | `bool` | `false` | no |
-| tls\_port | The port for the TLS listener | `number` | `443` | no |
-| tls\_ssl\_policy | The name of the SSL Policy for the listener | `string` | `"ELBSecurityPolicy-2016-08"` | no |
-| udp\_enabled | A boolean flag to enable/disable UDP listener | `bool` | `false` | no |
-| udp\_port | The port for the UDP listener | `number` | `53` | no |
-| vpc\_id | VPC ID to associate with NLB | `string` | n/a | yes |
+| <a name="input_access_logs_enabled"></a> [access\_logs\_enabled](#input\_access\_logs\_enabled) | A boolean flag to enable/disable access\_logs | `bool` | `true` | no |
+| <a name="input_access_logs_prefix"></a> [access\_logs\_prefix](#input\_access\_logs\_prefix) | The S3 log bucket prefix | `string` | `""` | no |
+| <a name="input_access_logs_s3_bucket_id"></a> [access\_logs\_s3\_bucket\_id](#input\_access\_logs\_s3\_bucket\_id) | An external S3 Bucket name to store access logs in. If specified, no logging bucket will be created. | `string` | `null` | no |
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
+| <a name="input_certificate_arn"></a> [certificate\_arn](#input\_certificate\_arn) | The ARN of the default SSL certificate for HTTPS listener | `string` | `""` | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| <a name="input_cross_zone_load_balancing_enabled"></a> [cross\_zone\_load\_balancing\_enabled](#input\_cross\_zone\_load\_balancing\_enabled) | A boolean flag to enable/disable cross zone load balancing | `bool` | `true` | no |
+| <a name="input_deletion_protection_enabled"></a> [deletion\_protection\_enabled](#input\_deletion\_protection\_enabled) | A boolean flag to enable/disable deletion protection for NLB | `bool` | `false` | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_deregistration_delay"></a> [deregistration\_delay](#input\_deregistration\_delay) | The amount of time to wait in seconds before changing the state of a deregistering target to unused | `number` | `15` | no |
+| <a name="input_enable_glacier_transition"></a> [enable\_glacier\_transition](#input\_enable\_glacier\_transition) | Enables the transition of lb logs to AWS Glacier | `bool` | `true` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_expiration_days"></a> [expiration\_days](#input\_expiration\_days) | Number of days after which to expunge s3 logs | `number` | `90` | no |
+| <a name="input_glacier_transition_days"></a> [glacier\_transition\_days](#input\_glacier\_transition\_days) | Number of days after which to move s3 logs to the glacier storage tier | `number` | `60` | no |
+| <a name="input_health_check_enabled"></a> [health\_check\_enabled](#input\_health\_check\_enabled) | A boolean flag to enable/disable the NLB health checks | `bool` | `true` | no |
+| <a name="input_health_check_interval"></a> [health\_check\_interval](#input\_health\_check\_interval) | The duration in seconds in between health checks | `number` | `10` | no |
+| <a name="input_health_check_path"></a> [health\_check\_path](#input\_health\_check\_path) | The destination for the health check request | `string` | `"/"` | no |
+| <a name="input_health_check_port"></a> [health\_check\_port](#input\_health\_check\_port) | The port to send the health check request to (defaults to `traffic-port`) | `number` | `null` | no |
+| <a name="input_health_check_protocol"></a> [health\_check\_protocol](#input\_health\_check\_protocol) | The protocol to use for the health check request | `string` | `null` | no |
+| <a name="input_health_check_threshold"></a> [health\_check\_threshold](#input\_health\_check\_threshold) | The number of consecutive health checks successes required before considering an unhealthy target healthy, or failures required before considering a health target unhealthy | `number` | `2` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_internal"></a> [internal](#input\_internal) | A boolean flag to determine whether the NLB should be internal | `bool` | `false` | no |
+| <a name="input_ip_address_type"></a> [ip\_address\_type](#input\_ip\_address\_type) | The type of IP addresses used by the subnets for your load balancer. The possible values are `ipv4` and `dualstack`. | `string` | `"ipv4"` | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_lifecycle_rule_enabled"></a> [lifecycle\_rule\_enabled](#input\_lifecycle\_rule\_enabled) | A boolean that indicates whether the s3 log bucket lifecycle rule should be enabled. | `bool` | `false` | no |
+| <a name="input_name"></a> [name](#input\_name) | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
+| <a name="input_nlb_access_logs_s3_bucket_force_destroy"></a> [nlb\_access\_logs\_s3\_bucket\_force\_destroy](#input\_nlb\_access\_logs\_s3\_bucket\_force\_destroy) | A boolean that indicates all objects should be deleted from the NLB access logs S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
+| <a name="input_noncurrent_version_expiration_days"></a> [noncurrent\_version\_expiration\_days](#input\_noncurrent\_version\_expiration\_days) | Specifies when noncurrent s3 log versions expire | `number` | `90` | no |
+| <a name="input_noncurrent_version_transition_days"></a> [noncurrent\_version\_transition\_days](#input\_noncurrent\_version\_transition\_days) | Specifies when noncurrent s3 log versions transition | `number` | `30` | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_standard_transition_days"></a> [standard\_transition\_days](#input\_standard\_transition\_days) | Number of days to persist logs in standard storage tier before moving to the infrequent access tier | `number` | `30` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of subnet IDs to associate with NLB | `list(string)` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
+| <a name="input_target_group_additional_tags"></a> [target\_group\_additional\_tags](#input\_target\_group\_additional\_tags) | The additional tags to apply to the default target group | `map(string)` | `{}` | no |
+| <a name="input_target_group_name"></a> [target\_group\_name](#input\_target\_group\_name) | The name for the default target group, uses a module label name if left empty | `string` | `""` | no |
+| <a name="input_target_group_port"></a> [target\_group\_port](#input\_target\_group\_port) | The port for the default target group | `number` | `80` | no |
+| <a name="input_target_group_target_type"></a> [target\_group\_target\_type](#input\_target\_group\_target\_type) | The type (`instance`, `ip` or `lambda`) of targets that can be registered with the default target group | `string` | `"ip"` | no |
+| <a name="input_tcp_enabled"></a> [tcp\_enabled](#input\_tcp\_enabled) | A boolean flag to enable/disable TCP listener | `bool` | `true` | no |
+| <a name="input_tcp_port"></a> [tcp\_port](#input\_tcp\_port) | The port for the TCP listener | `number` | `80` | no |
+| <a name="input_tls_enabled"></a> [tls\_enabled](#input\_tls\_enabled) | A boolean flag to enable/disable TLS listener | `bool` | `false` | no |
+| <a name="input_tls_port"></a> [tls\_port](#input\_tls\_port) | The port for the TLS listener | `number` | `443` | no |
+| <a name="input_tls_ssl_policy"></a> [tls\_ssl\_policy](#input\_tls\_ssl\_policy) | The name of the SSL Policy for the listener | `string` | `"ELBSecurityPolicy-2016-08"` | no |
+| <a name="input_udp_enabled"></a> [udp\_enabled](#input\_udp\_enabled) | A boolean flag to enable/disable UDP listener | `bool` | `false` | no |
+| <a name="input_udp_port"></a> [udp\_port](#input\_udp\_port) | The port for the UDP listener | `number` | `53` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID to associate with NLB | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| access\_logs\_bucket\_id | The S3 bucket ID for access logs |
-| default\_listener\_arn | The ARN of the default listener |
-| default\_target\_group\_arn | The default target group ARN |
-| listener\_arns | A list of all the listener ARNs |
-| nlb\_arn | The ARN of the NLB |
-| nlb\_arn\_suffix | The ARN suffix of the NLB |
-| nlb\_dns\_name | DNS name of NLB |
-| nlb\_name | The ARN suffix of the NLB |
-| nlb\_zone\_id | The ID of the zone which NLB is provisioned |
-| tls\_listener\_arn | The ARN of the TLS listener |
-
+| <a name="output_access_logs_bucket_id"></a> [access\_logs\_bucket\_id](#output\_access\_logs\_bucket\_id) | The S3 bucket ID for access logs |
+| <a name="output_default_listener_arn"></a> [default\_listener\_arn](#output\_default\_listener\_arn) | The ARN of the default listener |
+| <a name="output_default_target_group_arn"></a> [default\_target\_group\_arn](#output\_default\_target\_group\_arn) | The default target group ARN |
+| <a name="output_listener_arns"></a> [listener\_arns](#output\_listener\_arns) | A list of all the listener ARNs |
+| <a name="output_nlb_arn"></a> [nlb\_arn](#output\_nlb\_arn) | The ARN of the NLB |
+| <a name="output_nlb_arn_suffix"></a> [nlb\_arn\_suffix](#output\_nlb\_arn\_suffix) | The ARN suffix of the NLB |
+| <a name="output_nlb_dns_name"></a> [nlb\_dns\_name](#output\_nlb\_dns\_name) | DNS name of NLB |
+| <a name="output_nlb_name"></a> [nlb\_name](#output\_nlb\_name) | The ARN suffix of the NLB |
+| <a name="output_nlb_zone_id"></a> [nlb\_zone\_id](#output\_nlb\_zone\_id) | The ID of the zone which NLB is provisioned |
+| <a name="output_tls_listener_arn"></a> [tls\_listener\_arn](#output\_tls\_listener\_arn) | The ARN of the TLS listener |
 <!-- markdownlint-restore -->

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -18,8 +18,6 @@ access_logs_enabled = true
 
 nlb_access_logs_s3_bucket_force_destroy = true
 
-access_logs_region = "us-east-2"
-
 cross_zone_load_balancing_enabled = false
 
 ip_address_type = "ipv4"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -12,9 +12,9 @@ module "vpc" {
 }
 
 module "subnets" {
-  source               = "cloudposse/dynamic-subnets/aws"
-  version              = "0.39.0"
-  
+  source  = "cloudposse/dynamic-subnets/aws"
+  version = "0.39.0"
+
   availability_zones   = var.availability_zones
   vpc_id               = module.vpc.vpc_id
   igw_id               = module.vpc.igw_id

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 module "vpc" {
   source  = "cloudposse/vpc/aws"
-  version = "0.18.1"
+  version = "0.21.1"
 
   cidr_block = var.vpc_cidr_block
 
@@ -13,7 +13,8 @@ module "vpc" {
 
 module "subnets" {
   source               = "cloudposse/dynamic-subnets/aws"
-  version              = "0.33.0"
+  version              = "0.39.0"
+  
   availability_zones   = var.availability_zones
   vpc_id               = module.vpc.vpc_id
   igw_id               = module.vpc.igw_id
@@ -33,7 +34,6 @@ module "nlb" {
   tcp_enabled                             = var.tcp_enabled
   access_logs_enabled                     = var.access_logs_enabled
   nlb_access_logs_s3_bucket_force_destroy = var.nlb_access_logs_s3_bucket_force_destroy
-  access_logs_region                      = var.access_logs_region
   cross_zone_load_balancing_enabled       = var.cross_zone_load_balancing_enabled
   ip_address_type                         = var.ip_address_type
   deletion_protection_enabled             = var.deletion_protection_enabled

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -28,9 +28,10 @@ variable "access_logs_enabled" {
   description = "A boolean flag to enable/disable access_logs"
 }
 
-variable "access_logs_region" {
+variable "access_logs_s3_bucket_id" {
   type        = string
-  description = "The region for the access_logs S3 bucket"
+  default     = null
+  description = "An external S3 Bucket name to store access logs in. If specified, no logging bucket will be created."
 }
 
 variable "cross_zone_load_balancing_enabled" {

--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,7 @@ module "access_logs" {
   source  = "cloudposse/lb-s3-bucket/aws"
   version = "0.11.4"
 
+  enabled                            = module.this.enabled && var.access_logs_enabled && var.access_logs_s3_bucket_id == null
   lifecycle_rule_enabled             = var.lifecycle_rule_enabled
   enable_glacier_transition          = var.enable_glacier_transition
   expiration_days                    = var.expiration_days
@@ -19,7 +20,6 @@ module "access_logs" {
   noncurrent_version_transition_days = var.noncurrent_version_transition_days
   standard_transition_days           = var.standard_transition_days
   force_destroy                      = var.nlb_access_logs_s3_bucket_force_destroy
-  enabled                            = false # Cannot apparently use encryption with S3 logs for NLB, even if using AES256. See https://github.com/cloudposse/terraform-aws-lb-s3-bucket/issues/9 for discussion.
 
   context = module.this.context
 }
@@ -35,13 +35,11 @@ resource "aws_lb" "default" {
   ip_address_type                  = var.ip_address_type
   enable_deletion_protection       = var.deletion_protection_enabled
 
-  /* TODO: re-enable when bucket encryption issue is resolved for NLBs
-access_logs {
-  bucket  = module.access_logs.bucket_id
-  prefix  = var.access_logs_prefix
-  enabled = var.access_logs_enabled
-}
-*/
+  access_logs {
+    bucket  = try(element(compact([var.access_logs_s3_bucket_id, module.access_logs.bucket_id]), 0), "")
+    prefix  = var.access_logs_prefix
+    enabled = var.access_logs_enabled
+  }
 }
 
 module "default_target_group_label" {

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ locals {
 
 module "access_logs" {
   source  = "cloudposse/lb-s3-bucket/aws"
-  version = "0.11.4"
+  version = "0.12.0"
 
   enabled                            = module.this.enabled && var.access_logs_enabled && var.access_logs_s3_bucket_id == null
   lifecycle_rule_enabled             = var.lifecycle_rule_enabled

--- a/main.tf
+++ b/main.tf
@@ -25,6 +25,7 @@ module "access_logs" {
 }
 
 resource "aws_lb" "default" {
+  #bridgecrew:skip=BC_AWS_NETWORKING_41 - Skipping `Ensure that ALB drops HTTP headers` check. Only valid for Load Balancers of type application.
   name               = module.this.id
   tags               = module.this.tags
   internal           = var.internal

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,31 +1,31 @@
 output "nlb_name" {
   description = "The ARN suffix of the NLB"
-  value       = aws_lb.default.name
+  value       = join("", aws_lb.default.*.name)
 }
 
 output "nlb_arn" {
   description = "The ARN of the NLB"
-  value       = aws_lb.default.arn
+  value       = join("", aws_lb.default.*.arn)
 }
 
 output "nlb_arn_suffix" {
   description = "The ARN suffix of the NLB"
-  value       = aws_lb.default.arn_suffix
+  value       = join("", aws_lb.default.*.arn_suffix)
 }
 
 output "nlb_dns_name" {
   description = "DNS name of NLB"
-  value       = aws_lb.default.dns_name
+  value       = join("", aws_lb.default.*.dns_name)
 }
 
 output "nlb_zone_id" {
   description = "The ID of the zone which NLB is provisioned"
-  value       = aws_lb.default.zone_id
+  value       = join("", aws_lb.default.*.zone_id)
 }
 
 output "default_target_group_arn" {
   description = "The default target group ARN"
-  value       = aws_lb_target_group.default.arn
+  value       = join("", aws_lb_target_group.default.*.arn)
 }
 
 output "default_listener_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -98,10 +98,10 @@ variable "access_logs_enabled" {
   description = "A boolean flag to enable/disable access_logs"
 }
 
-variable "access_logs_region" {
+variable "access_logs_s3_bucket_id" {
   type        = string
-  default     = "us-east-1"
-  description = "The region for the access_logs S3 bucket"
+  default     = null
+  description = "An external S3 Bucket name to store access logs in. If specified, no logging bucket will be created."
 }
 
 variable "cross_zone_load_balancing_enabled" {


### PR DESCRIPTION
## what
* synchronizing part of codebase to match terraform-aws-alb
* access_logs_region is no longer used
* bumping vpc and subnet versions to the latest releases for testing
* syncing access_logs to match terraform-aws-alb. this enables 2 things - optional logging and the ability to log to a specified s3 bucket rather than the provided bucket.


## why
* best practices
* we need to enable logging for all load balancers (business use case). 

## references
* N/A

