### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <!-- markdownlint-disable -->
 # terraform-aws-nlb [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-aws-nlb.svg)](https://github.com/cloudposse/terraform-aws-nlb/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
 <!-- markdownlint-restore -->


### PR DESCRIPTION
Newline on line 1 of README causes GitLab rendering to break.

## what

Remove newline on line 1 of README.md that is causing GitLab mirrors of the project to not render correctly.

## why

Enhance usability.

## references
None

