### PR TITLE
Add preserve_client_ip flag for the target group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -108,6 +108,7 @@ resource "aws_lb_target_group" "default" {
   name                 = var.target_group_name == "" ? module.default_target_group_label.id : var.target_group_name
   port                 = var.target_group_port
   protocol             = local.target_group_protocol
+  preserve_client_ip   = var.target_group_preserve_client_ip
   proxy_protocol_v2    = var.target_group_proxy_protocol_v2
   slow_start           = var.slow_start
   target_type          = var.target_group_target_type

--- a/variables.tf
+++ b/variables.tf
@@ -18,8 +18,8 @@ variable "eip_allocation_ids" {
   type        = list(string)
   default     = []
   description = <<-EOT
-    Allocation ID for EIP for subnets. 
-    The length of the list must correspond to the number of defined subnents. 
+    Allocation ID for EIP for subnets.
+    The length of the list must correspond to the number of defined subnents.
     If the `subnet_mapping_enabled` variable is not defined and enabled `subnet_mapping_enabled`, EIPs will be created
     EOT
 }
@@ -82,6 +82,12 @@ variable "target_group_proxy_protocol_v2" {
   type        = bool
   default     = false
   description = "A boolean flag to enable/disable proxy protocol v2 support"
+}
+
+variable "target_group_preserve_client_ip" {
+  type        = bool
+  default     = false
+  description = "A boolean flag to enable/disable client IP preservation."
 }
 
 variable "tls_port" {


### PR DESCRIPTION
## what

- Added preserve_client_ip flag for the target group

## why

- NLBs need to be able to preserve the client IP

## references
