### PR TITLE
Support ip_address_type and Fix Readme Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ For automated test of the complete example using `bats` and `Terratest`, see [te
     deregistration_delay                            = var.deregistration_delay
     health_check_path                               = var.health_check_path
     health_check_timeout                            = var.health_check_timeout
-    health_check_healthy_threshold                  = var.health_check_healthy_threshold
+    health_check_threshold                          = var.health_check_healthy_threshold
     health_check_unhealthy_threshold                = var.health_check_unhealthy_threshold
     health_check_interval                           = var.health_check_interval
     target_group_port                               = var.target_group_port

--- a/README.md
+++ b/README.md
@@ -33,12 +33,6 @@ Terraform module to create an NLB and a default NLB target and related security 
 ---
 
 This project is part of our comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps.
-[<img align="right" title="Share via Email" src="https://docs.cloudposse.com/images/ionicons/ios-email-outline-2.0.1-16x16-999999.svg"/>][share_email]
-[<img align="right" title="Share on Google+" src="https://docs.cloudposse.com/images/ionicons/social-googleplus-outline-2.0.1-16x16-999999.svg" />][share_googleplus]
-[<img align="right" title="Share on Facebook" src="https://docs.cloudposse.com/images/ionicons/social-facebook-outline-2.0.1-16x16-999999.svg" />][share_facebook]
-[<img align="right" title="Share on Reddit" src="https://docs.cloudposse.com/images/ionicons/social-reddit-outline-2.0.1-16x16-999999.svg" />][share_reddit]
-[<img align="right" title="Share on LinkedIn" src="https://docs.cloudposse.com/images/ionicons/social-linkedin-outline-2.0.1-16x16-999999.svg" />][share_linkedin]
-[<img align="right" title="Share on Twitter" src="https://docs.cloudposse.com/images/ionicons/social-twitter-outline-2.0.1-16x16-999999.svg" />][share_twitter]
 
 
 [![Terraform Open Source Modules](https://docs.cloudposse.com/images/terraform-open-source-modules.svg)][terraform_modules]
@@ -264,6 +258,7 @@ Available targets:
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_target_group_additional_tags"></a> [target\_group\_additional\_tags](#input\_target\_group\_additional\_tags) | The additional tags to apply to the default target group | `map(string)` | `{}` | no |
 | <a name="input_target_group_enabled"></a> [target\_group\_enabled](#input\_target\_group\_enabled) | Whether or not to create the default target group and listener | `bool` | `true` | no |
+| <a name="input_target_group_ip_address_type"></a> [target\_group\_ip\_address\_type](#input\_target\_group\_ip\_address\_type) | The type of IP addresses used by the target group. The possible values are `ipv4` and `ipv6`. | `string` | `"ipv4"` | no |
 | <a name="input_target_group_name"></a> [target\_group\_name](#input\_target\_group\_name) | The name for the default target group, uses a module label name if left empty | `string` | `""` | no |
 | <a name="input_target_group_port"></a> [target\_group\_port](#input\_target\_group\_port) | The port for the default target group | `number` | `80` | no |
 | <a name="input_target_group_preserve_client_ip"></a> [target\_group\_preserve\_client\_ip](#input\_target\_group\_preserve\_client\_ip) | A boolean flag to enable/disable client IP preservation. | `bool` | `false` | no |
@@ -300,8 +295,6 @@ Available targets:
 ## Share the Love
 
 Like this project? Please give it a ★ on [our GitHub](https://github.com/cloudposse/terraform-aws-nlb)! (it helps us **a lot**)
-
-Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
 
 
@@ -345,10 +338,6 @@ We deliver 10x the value for a fraction of the cost of a full-time engineer. Our
 
 Join our [Open Source Community][slack] on Slack. It's **FREE** for everyone! Our "SweetOps" community is where you get to talk with others who share a similar vision for how to rollout and manage infrastructure. This is the best place to talk shop, ask questions, solicit feedback, and work together as a community to build totally *sweet* infrastructure.
 
-## Discourse Forums
-
-Participate in our [Discourse Forums][discourse]. Here you'll find answers to commonly asked questions. Most questions will be related to the enormous number of projects we support on our GitHub. Come here to collaborate on answers, find solutions, and get ideas about the products and services we value. It only takes a minute to get started! Just sign in with SSO using your GitHub account.
-
 ## Newsletter
 
 Sign up for [our newsletter][newsletter] that covers everything on our technology radar.  Receive updates on what we're up to on GitHub as well as awesome new projects we discover.
@@ -359,7 +348,18 @@ Sign up for [our newsletter][newsletter] that covers everything on our technolog
 
 [![zoom](https://img.cloudposse.com/fit-in/200x200/https://cloudposse.com/wp-content/uploads/2019/08/Powered-by-Zoom.png")][office_hours]
 
-## Contributing
+## ✨ Contributing
+
+
+
+This project is under active development, and we encourage contributions from our community. 
+Many thanks to our outstanding contributors:
+
+<a href="https://github.com/cloudposse/terraform-aws-nlb/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=cloudposse/terraform-aws-nlb&max=24" />
+</a>
+
+
 
 ### Bug Reports & Feature Requests
 
@@ -433,27 +433,7 @@ We're a [DevOps Professional Services][hire] company based in Los Angeles, CA. W
 
 We offer [paid support][commercial_support] on all of our projects.
 
-Check out [our other projects][github], [follow us on twitter][twitter], [apply for a job][jobs], or [hire us][hire] to help with your cloud strategy and implementation.
-
-
-
-### Contributors
-
-<!-- markdownlint-disable -->
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Sarkis Varozian][sarkis_avatar]][sarkis_homepage]<br/>[Sarkis Varozian][sarkis_homepage] |
-|---|---|---|---|
-<!-- markdownlint-restore -->
-
-  [osterman_homepage]: https://github.com/osterman
-  [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png
-  [goruha_homepage]: https://github.com/goruha
-  [goruha_avatar]: https://img.cloudposse.com/150x150/https://github.com/goruha.png
-  [aknysh_homepage]: https://github.com/aknysh
-  [aknysh_avatar]: https://img.cloudposse.com/150x150/https://github.com/aknysh.png
-  [sarkis_homepage]: https://github.com/sarkis
-  [sarkis_avatar]: https://img.cloudposse.com/150x150/https://github.com/sarkis.png
-
-[![README Footer][readme_footer_img]][readme_footer_link]
+Check out [our other projects][github], [follow us on twitter][twitter], [apply for a job][jobs], or [hire us][hire] to help with your cloud strategy and implementation.[![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
 <!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
@@ -463,12 +443,10 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [jobs]: https://cpco.io/jobs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-nlb&utm_content=jobs
   [hire]: https://cpco.io/hire?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-nlb&utm_content=hire
   [slack]: https://cpco.io/slack?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-nlb&utm_content=slack
-  [linkedin]: https://cpco.io/linkedin?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-nlb&utm_content=linkedin
   [twitter]: https://cpco.io/twitter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-nlb&utm_content=twitter
   [testimonial]: https://cpco.io/leave-testimonial?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-nlb&utm_content=testimonial
   [office_hours]: https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-nlb&utm_content=office_hours
   [newsletter]: https://cpco.io/newsletter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-nlb&utm_content=newsletter
-  [discourse]: https://ask.sweetops.com/?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-nlb&utm_content=discourse
   [email]: https://cpco.io/email?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-nlb&utm_content=email
   [commercial_support]: https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-nlb&utm_content=commercial_support
   [we_love_open_source]: https://cpco.io/we-love-open-source?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-nlb&utm_content=we_love_open_source
@@ -479,11 +457,5 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [readme_footer_link]: https://cloudposse.com/readme/footer/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-nlb&utm_content=readme_footer_link
   [readme_commercial_support_img]: https://cloudposse.com/readme/commercial-support/img
   [readme_commercial_support_link]: https://cloudposse.com/readme/commercial-support/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-nlb&utm_content=readme_commercial_support_link
-  [share_twitter]: https://twitter.com/intent/tweet/?text=terraform-aws-nlb&url=https://github.com/cloudposse/terraform-aws-nlb
-  [share_linkedin]: https://www.linkedin.com/shareArticle?mini=true&title=terraform-aws-nlb&url=https://github.com/cloudposse/terraform-aws-nlb
-  [share_reddit]: https://reddit.com/submit/?url=https://github.com/cloudposse/terraform-aws-nlb
-  [share_facebook]: https://facebook.com/sharer/sharer.php?u=https://github.com/cloudposse/terraform-aws-nlb
-  [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-nlb
-  [share_email]: mailto:?subject=terraform-aws-nlb&body=https://github.com/cloudposse/terraform-aws-nlb
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-nlb?pixel&cs=github&cm=readme&an=terraform-aws-nlb
 <!-- markdownlint-restore -->

--- a/README.yaml
+++ b/README.yaml
@@ -72,7 +72,7 @@ usage: |-
       deregistration_delay                            = var.deregistration_delay
       health_check_path                               = var.health_check_path
       health_check_timeout                            = var.health_check_timeout
-      health_check_healthy_threshold                  = var.health_check_healthy_threshold
+      health_check_threshold                          = var.health_check_healthy_threshold
       health_check_unhealthy_threshold                = var.health_check_unhealthy_threshold
       health_check_interval                           = var.health_check_interval
       target_group_port                               = var.target_group_port

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -91,7 +91,7 @@
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_target_group_additional_tags"></a> [target\_group\_additional\_tags](#input\_target\_group\_additional\_tags) | The additional tags to apply to the default target group | `map(string)` | `{}` | no |
 | <a name="input_target_group_enabled"></a> [target\_group\_enabled](#input\_target\_group\_enabled) | Whether or not to create the default target group and listener | `bool` | `true` | no |
-| <a name="input_target_group_ip_address_type"></a> [target\_group\_ip\_address\_type](#input\_target\_group\_ip\_address\_type) | The type of IP addresses used by the target group. The possible values are `ipv4` and `ipv6` | `string` | `ipv4` | no |
+| <a name="input_target_group_ip_address_type"></a> [target\_group\_ip\_address\_type](#input\_target\_group\_ip\_address\_type) | The type of IP addresses used by the target group. The possible values are `ipv4` and `ipv6`. | `string` | `"ipv4"` | no |
 | <a name="input_target_group_name"></a> [target\_group\_name](#input\_target\_group\_name) | The name for the default target group, uses a module label name if left empty | `string` | `""` | no |
 | <a name="input_target_group_port"></a> [target\_group\_port](#input\_target\_group\_port) | The port for the default target group | `number` | `80` | no |
 | <a name="input_target_group_preserve_client_ip"></a> [target\_group\_preserve\_client\_ip](#input\_target\_group\_preserve\_client\_ip) | A boolean flag to enable/disable client IP preservation. | `bool` | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -91,6 +91,7 @@
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_target_group_additional_tags"></a> [target\_group\_additional\_tags](#input\_target\_group\_additional\_tags) | The additional tags to apply to the default target group | `map(string)` | `{}` | no |
 | <a name="input_target_group_enabled"></a> [target\_group\_enabled](#input\_target\_group\_enabled) | Whether or not to create the default target group and listener | `bool` | `true` | no |
+| <a name="input_target_group_ip_address_type"></a> [target\_group\_ip\_address\_type](#input\_target\_group\_ip\_address\_type) | The type of IP addresses used by the target group. The possible values are `ipv4` and `ipv6` | `string` | `ipv4` | no |
 | <a name="input_target_group_name"></a> [target\_group\_name](#input\_target\_group\_name) | The name for the default target group, uses a module label name if left empty | `string` | `""` | no |
 | <a name="input_target_group_port"></a> [target\_group\_port](#input\_target\_group\_port) | The port for the default target group | `number` | `80` | no |
 | <a name="input_target_group_preserve_client_ip"></a> [target\_group\_preserve\_client\_ip](#input\_target\_group\_preserve\_client\_ip) | A boolean flag to enable/disable client IP preservation. | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -113,6 +113,7 @@ resource "aws_lb_target_group" "default" {
   proxy_protocol_v2    = var.target_group_proxy_protocol_v2
   slow_start           = var.slow_start
   target_type          = var.target_group_target_type
+  ip_address_type      = var.target_group_target_type == "ip" ? var.target_ip_address_type : null
   vpc_id               = var.vpc_id
 
   health_check {

--- a/main.tf
+++ b/main.tf
@@ -113,7 +113,7 @@ resource "aws_lb_target_group" "default" {
   proxy_protocol_v2    = var.target_group_proxy_protocol_v2
   slow_start           = var.slow_start
   target_type          = var.target_group_target_type
-  ip_address_type      = var.target_group_target_type == "ip" ? var.target_ip_address_type : null
+  ip_address_type      = var.target_group_target_type == "ip" ? var.target_group_ip_address_type : null
   vpc_id               = var.vpc_id
 
   health_check {

--- a/variables.tf
+++ b/variables.tf
@@ -66,6 +66,12 @@ variable "target_group_target_type" {
   description = "The type (`instance`, `ip` or `lambda`) of targets that can be registered with the default target group"
 }
 
+variable "target_ip_address_type" {
+  type        = string
+  default     = "ipv4"
+  description = "The type of IP addresses used by the target group. The possible values are `ipv4` and `ipv6`."
+}
+
 variable "target_group_additional_tags" {
   type        = map(string)
   default     = {}

--- a/variables.tf
+++ b/variables.tf
@@ -66,7 +66,7 @@ variable "target_group_target_type" {
   description = "The type (`instance`, `ip` or `lambda`) of targets that can be registered with the default target group"
 }
 
-variable "target_ip_address_type" {
+variable "target_group_ip_address_type" {
   type        = string
   default     = "ipv4"
   description = "The type of IP addresses used by the target group. The possible values are `ipv4` and `ipv6`."


### PR DESCRIPTION
## what
Fix typo in readme example.

Added support for IPv6 target group in ip mode

## why
1. invalid variable name was there in the readme example
2. target groups in ip mode allow targets to register using ipv6. where service runs in ipv6 mode. only

