### PR TITLE
fix: enabled input for NLB resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -189,7 +189,7 @@ resource "aws_lb_target_group" "default" {
 
 resource "aws_lb_listener" "default" {
   count             = var.target_group_enabled && (var.tcp_enabled || var.udp_enabled) ? 1 : 0
-  load_balancer_arn = aws_lb.default.arn
+  load_balancer_arn = one(aws_lb.default[*].arn)
   port              = local.listener_port
   protocol          = local.listener_proto
 
@@ -201,7 +201,7 @@ resource "aws_lb_listener" "default" {
 
 resource "aws_lb_listener" "tls" {
   count             = var.target_group_enabled && var.tls_enabled ? 1 : 0
-  load_balancer_arn = aws_lb.default.arn
+  load_balancer_arn = one(aws_lb.default[*].arn)
   port              = var.tls_port
   protocol          = "TLS"
   ssl_policy        = var.tls_ssl_policy

--- a/main.tf
+++ b/main.tf
@@ -108,6 +108,7 @@ module "lb_label" {
 
 resource "aws_lb" "default" {
   #bridgecrew:skip=BC_AWS_NETWORKING_41 - Skipping `Ensure that ALB drops HTTP headers` check. Only valid for Load Balancers of type application.
+  count              = module.this.enabled ? 1 : 0
   name               = module.lb_label.id
   tags               = module.lb_label.tags
   internal           = var.internal


### PR DESCRIPTION
- Add a conditional check for module enabling in the `aws_lb` resource count

## what

https://github.com/cloudposse/terraform-aws-nlb/issues/52
`enabled` input not set on nlb resource. Adding it.

~it will be a breaking change. Resource `aws_lb.default` will become `aws_lb.default[0]` in state.~

Terraform will rename the resource in state;

```terraform
Terraform will perform the following actions:

  # aws_lb.default has moved to aws_lb.default[0]
    resource "aws_lb" "default" {
        id                               = "arn:aws:elasticloadbalancing:ap-southeast-2:123456789012:loadbalancer/net/nlb/1234567890123456"
        name                             = "nlb"
        tags                             = {
            "Name" = "nlb"
        }
        # (14 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

Plan: 0 to add, 0 to change, 0 to destroy.
```

## why

Usefull feature.

## references

https://github.com/cloudposse/terraform-aws-nlb/issues/52
