### PR TITLE
Enable security groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2022 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2023 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,47 @@ locals {
   health_check_protocol = coalesce(var.health_check_protocol, local.target_group_protocol)
 }
 
+resource "aws_security_group" "default" {
+  count       = module.this.enabled && var.security_group_enabled ? 1 : 0
+  description = "Controls access to the ALB (HTTP/HTTPS)"
+  vpc_id      = var.vpc_id
+  name        = module.this.id
+  tags        = module.this.tags
+}
+
+resource "aws_security_group_rule" "egress" {
+  count             = module.this.enabled && var.security_group_enabled ? 1 : 0
+  type              = "egress"
+  from_port         = "0"
+  to_port           = "0"
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = join("", aws_security_group.default.*.id)
+}
+
+resource "aws_security_group_rule" "http_ingress" {
+  count             = module.this.enabled && var.security_group_enabled && var.http_enabled ? 1 : 0
+  type              = "ingress"
+  from_port         = var.http_port
+  to_port           = var.http_port
+  protocol          = "tcp"
+  cidr_blocks       = var.http_ingress_cidr_blocks
+  prefix_list_ids   = var.http_ingress_prefix_list_ids
+  security_group_id = join("", aws_security_group.default.*.id)
+}
+
+resource "aws_security_group_rule" "https_ingress" {
+  count             = module.this.enabled && var.security_group_enabled && var.https_enabled ? 1 : 0
+  type              = "ingress"
+  from_port         = var.https_port
+  to_port           = var.https_port
+  protocol          = "tcp"
+  cidr_blocks       = var.https_ingress_cidr_blocks
+  prefix_list_ids   = var.https_ingress_prefix_list_ids
+  security_group_id = join("", aws_security_group.default.*.id)
+}
+
+
 module "access_logs" {
   source  = "cloudposse/lb-s3-bucket/aws"
   version = "0.16.3"
@@ -48,6 +89,9 @@ resource "aws_lb" "default" {
   internal           = var.internal
   load_balancer_type = "network"
 
+  security_groups = compact(
+    concat(var.security_group_ids, [join("", aws_security_group.default.*.id)]),
+  )
   subnets                          = var.subnet_ids
   enable_cross_zone_load_balancing = var.cross_zone_load_balancing_enabled
   ip_address_type                  = var.ip_address_type

--- a/main.tf
+++ b/main.tf
@@ -113,19 +113,19 @@ resource "aws_lb_target_group" "default" {
 
 resource "aws_lb_listener" "default" {
   count             = module.this.enabled && var.tcp_enabled ? 1 : (module.this.enabled && var.udp_enabled ? 1 : 0)
-  load_balancer_arn = join(aws_lb.default.*.arn)
+  load_balancer_arn = join("", aws_lb.default.*.arn)
   port              = local.listener_port
   protocol          = local.listener_proto
 
   default_action {
-    target_group_arn = join(aws_lb_target_group.default.*.arn)
+    target_group_arn = join("", aws_lb_target_group.default.*.arn)
     type             = "forward"
   }
 }
 
 resource "aws_lb_listener" "tls" {
   count             = module.this.enabled && var.tls_enabled ? 1 : 0
-  load_balancer_arn = join(aws_lb.default.*.arn)
+  load_balancer_arn = join("", aws_lb.default.*.arn)
 
   port            = var.tls_port
   protocol        = "TLS"
@@ -133,7 +133,7 @@ resource "aws_lb_listener" "tls" {
   certificate_arn = var.certificate_arn
 
   default_action {
-    target_group_arn = join(aws_lb_target_group.default.*.arn)
+    target_group_arn = join("", aws_lb_target_group.default.*.arn)
     type             = "forward"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -255,3 +255,60 @@ variable "stickiness_cookie_name" {
   description = "Name of the application based cookie. Only needed when type is app_cookie"
 }
 
+variable "http_enabled" {
+  type        = bool
+  default     = true
+  description = "A boolean flag to enable/disable HTTP listener"
+}
+
+variable "http_ingress_cidr_blocks" {
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+  description = "List of CIDR blocks to allow in HTTP security group"
+}
+
+variable "http_ingress_prefix_list_ids" {
+  type        = list(string)
+  default     = []
+  description = "List of prefix list IDs for allowing access to HTTP ingress security group"
+}
+variable "https_ingress_cidr_blocks" {
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+  description = "List of CIDR blocks to allow in HTTPS security group"
+}
+
+variable "https_ingress_prefix_list_ids" {
+  type        = list(string)
+  default     = []
+  description = "List of prefix list IDs for allowing access to HTTPS ingress security group"
+}
+variable "https_port" {
+  type        = number
+  default     = 443
+  description = "The port for the HTTPS listener"
+}
+
+variable "http_port" {
+  type        = number
+  default     = 80
+  description = "The port for the HTTP listener"
+}
+
+variable "security_group_enabled" {
+  type        = bool
+  description = "Enables the security group"
+  default     = true
+}
+
+variable "https_enabled" {
+  type        = bool
+  default     = false
+  description = "A boolean flag to enable/disable HTTPS listener"
+}
+
+variable "security_group_ids" {
+  type        = list(string)
+  default     = []
+  description = "A list of additional security group IDs to allow access to ALB"
+}


### PR DESCRIPTION
## what

Adding security groups to NLB

## why

This will enable us to control traffic to the nlb

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
